### PR TITLE
feat: 파라미터 스토어 연동 & yml 분리 (#2, #3)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -8,6 +8,19 @@ group = 'com.palette'
 version = '0.0.1-SNAPSHOT'
 sourceCompatibility = '17'
 
+ext {
+	set('springCloudVersion', "2021.0.2")
+}
+
+dependencyManagement {
+	imports {
+		mavenBom "io.awspring.cloud:spring-cloud-aws-dependencies:2.3.3"
+	}
+	imports {
+		mavenBom "org.springframework.cloud:spring-cloud-dependencies:${springCloudVersion}"
+	}
+}
+
 configurations {
 	compileOnly {
 		extendsFrom annotationProcessor
@@ -37,6 +50,9 @@ dependencies {
 
 	// webflux
 	implementation 'org.springframework.boot:spring-boot-starter-webflux'
+
+	// AWS Pamametor store
+	implementation group: 'io.awspring.cloud', name: 'spring-cloud-starter-aws-parameter-store-config'
 
 	// test
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -1,0 +1,49 @@
+spring:
+  config:
+    activate:
+      on-profile: dev
+#       import: 'aws-parameterstore:' //파라미터 스토어 활성화시 주석 해제
+  datasource:
+    driver-class-name: com.mysql.cj.jdbc.Driver
+    url: jdbc:mysql://localhost:3306/palette_auth
+    username: dbuser
+    password: dbuser1234
+  jpa:
+    show-sql: true
+    hibernate.ddl-auto: update
+    properties.hibernate.format_sql: true
+
+# Logging
+logging.level.org.springframework.web: DEBUG
+
+# Cookie
+cookie:
+  properties:
+    domain: http://localhost:8080
+
+security:
+  jwt:
+    access-token:
+      secret-key: test
+      expire-length: 300000
+    refresh-token:
+      secret-key: test
+      expire-length: 3600000
+
+aws:
+  paramstore:
+    enabled: false
+    prefix: /config
+    profile-separator: _
+    name: application
+    fail-fast: false
+
+google:
+  client:
+    id: 1083383014162-l4rm9956ah9u94g6r0p7imjavdsvevfp.apps.googleusercontent.com
+    secret: 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
+    redirect-uri: http://localhost:8080/google/callback
+    grant-type: authorization_code
+  url:
+    access-token: https://oauth2.googleapis.com/token
+    profile: https://www.googleapis.com/oauth2/v2/userinfo

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -34,8 +34,8 @@ aws:
   paramstore:
     enabled: false
     prefix: /config
-    profile-separator: _
-    name: application
+    profile-separator: '-'
+    name: app-palette
     fail-fast: false
 
 google:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,37 +1,5 @@
 spring:
-  datasource:
-    driver-class-name: com.mysql.cj.jdbc.Driver
-    url: jdbc:mysql://localhost:3306/palette_auth
-    username: dbuser
-    password: dbuser1234
-  jpa:
-    show-sql: true
-    hibernate.ddl-auto: update
-    properties.hibernate.format_sql: true
-
-# Logging
-logging.level.org.springframework.web: DEBUG
-
-# Cookie
-cookie:
-  properties:
-    domain: http://localhost:8080
-
-security:
-  jwt:
-    access-token:
-      secret-key: test
-      expire-length: 300000
-    refresh-token:
-      secret-key: test
-      expire-length: 3600000
-
-google:
-  client:
-    id: 1083383014162-l4rm9956ah9u94g6r0p7imjavdsvevfp.apps.googleusercontent.com
-    secret: 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
-    redirect-uri: http://localhost:8080/google/callback
-    grant-type: authorization_code
-  url:
-    access-token: https://oauth2.googleapis.com/token
-    profile: https://www.googleapis.com/oauth2/v2/userinfo
+  profiles:
+    default: dev
+    group:
+      dev: dev


### PR DESCRIPTION
현재 aws 파라미터 스토어 구축이 되지 않아 실행시에 이상없도록 비활성화 시켰습니다.

yml은 개발,운영 환경 별 설정을 구분하기 위해 분리했습니다.
우선은 dev환경만 분리시켰습니다.

